### PR TITLE
Switch from bigint to bignum

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
  * Module dependencies.
  */
 
-var bigint = require('bigint');
+var bignum = require('bignum');
 
 /**
  * The offset from which druuid UUIDs are generated (in milliseconds).
@@ -28,7 +28,7 @@ exports.epoch = 0;
 exports.gen = function gen(date, epoch){
   if (!date) date = new Date();
   if (!epoch) epoch = exports.epoch;
-  var id = bigint(date - epoch).shiftLeft(64 - 41);
+  var id = bignum(date - epoch).shiftLeft(64 - 41);
   return id.or(Math.round(Math.random() * 1e16) % Math.pow(2, 64 - 41));
 };
 
@@ -48,6 +48,6 @@ exports.gen = function gen(date, epoch){
 
 exports.time = function(uuid, epoch){
   if (!epoch) epoch = exports.epoch;
-  var ms = bigint(uuid).shiftRight(64 - 41).toNumber();
+  var ms = bignum(uuid).shiftRight(64 - 41).toNumber();
   return new Date(ms + epoch);
 };

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test": "make test"
   },
   "dependencies": {
-    "bigint": "0.4.2"
+    "bignum": "0.6.2"
   },
   "devDependencies": {
     "mocha": "1.16.0",

--- a/test/druuid.test.js
+++ b/test/druuid.test.js
@@ -1,12 +1,12 @@
 
 var druuid = require('..')
-  , bigint = require('bigint');
+  , bignum = require('bignum');
 
 describe('druuid', function(){
   describe('.gen', function(){
     it('generates a UUID', function(){
       var uuid = druuid.gen();
-      uuid.should.be.instanceOf(bigint);
+      uuid.should.be.instanceOf(bignum);
       uuid.should.not.equal(druuid.gen());
     });
 


### PR DESCRIPTION
Bignum uses OpenSSL instead of libgmp, removing the need to handle external dependencies. cc: @isaachall

Details: https://github.com/justmoon/node-bignum
