### PR TITLE
Support Node 10

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
  * Module dependencies.
  */
 
-var bignum = require('bignum');
+var bigInteger = require('big-integer');
 
 /**
  * The offset from which druuid UUIDs are generated (in milliseconds).
@@ -28,7 +28,7 @@ exports.epoch = 0;
 exports.gen = function gen(date, epoch){
   if (!date) date = new Date();
   if (!epoch) epoch = exports.epoch;
-  var id = bignum(date - epoch).shiftLeft(64 - 41);
+  var id = bigInteger(date - epoch).shiftLeft(64 - 41);
   return id.or(Math.round(Math.random() * 1e16) % Math.pow(2, 64 - 41));
 };
 
@@ -48,6 +48,6 @@ exports.gen = function gen(date, epoch){
 
 exports.time = function(uuid, epoch){
   if (!epoch) epoch = exports.epoch;
-  var ms = bignum(uuid).shiftRight(64 - 41).toNumber();
+  var ms = bigInteger(uuid).shiftRight(64 - 41).toJSNumber();
   return new Date(ms + epoch);
 };

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test": "make test"
   },
   "dependencies": {
-    "bignum": "^0.12.5"
+    "big-integer": "^1.6.40"
   },
   "devDependencies": {
     "mocha": "1.16.0",

--- a/test/druuid.test.js
+++ b/test/druuid.test.js
@@ -1,12 +1,12 @@
 
 var druuid = require('..')
-  , bignum = require('bignum');
+  , bigInteger = require('big-integer');
 
 describe('druuid', function(){
   describe('.gen', function(){
     it('generates a UUID', function(){
       var uuid = druuid.gen();
-      uuid.should.be.instanceOf(bignum);
+      uuid.should.be.instanceOf(bigInteger);
       uuid.should.not.equal(druuid.gen());
     });
 


### PR DESCRIPTION
Originally I thought it's easier to just upgrade dependency library `bignum` to Node 10 compatible version. But after thinking for a while, I believed we should utilize Node 10 built-in `BigInt` support instead, and thus replaced `bignum` with `big-integer`, which is a simple polyfill for `BigInt`.