### PR TITLE
ci: upgrade GitHub Actions to Node.js 24-compatible versions

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -14,6 +14,6 @@ jobs:
   eslint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6.0.3
       - uses: stefanoeb/eslint-action@1.0.2
         continue-on-error: true

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -10,9 +10,6 @@ on:
       - master
       - qa
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   eslint:
     runs-on: ubuntu-latest

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -10,6 +10,9 @@ on:
       - master
       - qa
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   eslint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

### Problem
GitHub Actions is deprecating Node.js 20. Actions using Node.js 20 will be forced to run on Node.js 24 starting June 2026, and Node.js 20 will be fully removed from runners in September 2026. The `actions/checkout@v3` action used in the ESLint workflow runs on node16, which is also affected.

See: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

### Fix
Upgraded `actions/checkout` from `v3` (node16) to `v6.0.3` (node24) in the ESLint security check workflow.

The `stefanoeb/eslint-action@1.0.2` action uses a Docker runtime and is not affected by this deprecation.

### Files Changed
- `.github/workflows/eslint.yml` — upgraded `actions/checkout` from `v3` to `v6.0.3`; added `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` env flag for CI validation (to be removed before merge)

## Testing
CI runs on this PR with `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` to verify all JavaScript actions run under Node.js 24. The flag will be removed in a follow-up commit before merge.